### PR TITLE
More lenient peer dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "typescript": "^4.3.4"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">=16"
   }
 }


### PR DESCRIPTION
Fixes the "Could not resolve dependency" issue when trying to install this module while using some other React than v16.9.

Peer dependency requirements [should be lenient](https://nodejs.org/es/blog/npm/peer-dependencies/#using-peer-dependencies).
Fixes #15